### PR TITLE
Tooltips and Ontology download

### DIFF
--- a/api/src/main/java/de/sekmi/li2b2/api/ont/Concept.java
+++ b/api/src/main/java/de/sekmi/li2b2/api/ont/Concept.java
@@ -3,6 +3,7 @@ package de.sekmi.li2b2.api.ont;
 public interface Concept {
 	String getKey();
 	String getDisplayName();
+	String getTooltip();
 
 	default Integer getTotalNum(){return null;}
 	default Concept getSynonymTarget(){return null;}

--- a/client/src/main/java/de/sekmi/li2b2/client/ont/Concept.java
+++ b/client/src/main/java/de/sekmi/li2b2/client/ont/Concept.java
@@ -10,4 +10,5 @@ public class Concept {
 	public Integer level;
 	public String key;
 	public String name;
+	public String tooltip;
 }

--- a/server/src/main/java/de/sekmi/li2b2/services/OntologyService.java
+++ b/server/src/main/java/de/sekmi/li2b2/services/OntologyService.java
@@ -111,6 +111,7 @@ public class OntologyService extends AbstractService{
 			appendTextElement(c, "level", "0");
 			appendTextElement(c, "key", concept.getKey());
 			appendTextElement(c, "name", concept.getDisplayName());
+			appendTextElement(c, "tooltip", concept.getTooltip());
 			appendTextElement(c, "synonym_cd", "N");
 			appendTextElement(c, "visualattributes", concept.hasNarrower()?"FA":"LA");
 //			appendTextElement(c, "totalnum", "").setAttributeNS(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "nil", "true");;

--- a/server/src/main/java/de/sekmi/li2b2/services/impl/ConceptImpl.java
+++ b/server/src/main/java/de/sekmi/li2b2/services/impl/ConceptImpl.java
@@ -18,6 +18,8 @@ public class ConceptImpl implements Concept{
 	private String key;
 	@XmlElement
 	private String name;
+	@XmlElement
+	private String tooltip;
 	@XmlElementWrapper(name="narrower")
 	@XmlElement(name="concept")
 	private List<ConceptImpl> concepts;
@@ -30,6 +32,12 @@ public class ConceptImpl implements Concept{
 	@Override
 	public String getDisplayName() {
 		return name;
+	}
+	
+	
+	@Override
+	public String getTooltip() {
+		return tooltip;
 	}
 
 	@Override

--- a/server/src/test/java/de/sekmi/li2b2/services/MyBinder.java
+++ b/server/src/test/java/de/sekmi/li2b2/services/MyBinder.java
@@ -1,5 +1,8 @@
 package de.sekmi.li2b2.services;
 
+import java.net.MalformedURLException;
+import java.net.URL;
+
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 import de.sekmi.li2b2.api.crc.QueryManager;
@@ -28,7 +31,18 @@ public class MyBinder extends AbstractBinder{
 		
 		
 		// ontology
-		Ontology ont = OntologyImpl.parse(getClass().getResource("/ontology.xml"));
+		Ontology ont = null;
+		String onturl = System.getenv("i2b2ONTSERV_ONTURL");
+		if (onturl != null && onturl.matches("(?!file\\b)\\w+?:\\/\\/.*")) {
+			try {
+				URL url = new URL(onturl);
+				ont = OntologyImpl.parse(url);
+			} catch (MalformedURLException e) {
+				System.err.println("URL cannot be parsed! Maybe the wrong format?");
+			}
+		}
+		else
+			ont = OntologyImpl.parse(getClass().getResource("/ontology.xml"));
 		bind(ont).to(Ontology.class);
 		
 		// crc

--- a/server/src/test/resources/ontology.xml
+++ b/server/src/test/resources/ontology.xml
@@ -1,18 +1,22 @@
 <ontology>
 	<concept key="diag">
 		<name>Diagnosen (leer)</name>
+		<tooltip>Ein Konzept für die Sammlung von Diagnosen</tooltip>
 		<!-- narrower without concepts indicates an empty folder -->
 		<narrower/>
 	</concept>
 	<concept key="example">
 		<name>Beispiel</name>
+		<tooltip>Ein weiteres beispielhaftes Konzept</tooltip>
 		<narrower>
 			<concept key="examplesub">
 				<name>Sub</name>
+				<tooltip>Ein Beispiel für ein Unterkonzept</tooltip>
 				<!-- no narrower element indicates leaf -->
 			</concept>
 			<concept key="usw">
 				<name>Und so weiter</name>
+				<tooltip>Und so weiter</tooltip>
 			</concept>
 		</narrower>
 	</concept>


### PR DESCRIPTION
I have added two small features:
- tooltips can be specified in the ontology.xml and will be shown in the webclient
- the ontology.xml can be downloaded from an url which is read from the environment